### PR TITLE
Set prefix only if not defined in env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PREFIX = $(HOME)/.local/bin
+PREFIX ?= $(HOME)/.local/bin
 
 all: dragon
 


### PR DESCRIPTION
Without this I coudn't change prefix
```sh
env PREFIX=./foo make install                       
mkdir -p /home/teddy/.local/bin
cp dragon /home/teddy/.local/bin
```
