### PR TITLE
Some enhancements and bugfixes

### DIFF
--- a/dragon.c
+++ b/dragon.c
@@ -85,15 +85,15 @@ void drag_data_get(GtkWidget    *widget,
     if (info == TARGET_TYPE_URI) {
         if (verbose)
             printf("Writing as URI: %s\n", dd->uri);
-	
-	char** uris;
-	if(drag_all){
-	    uri_collection[uri_count] = NULL;
-	    uris = uri_collection;
-	} else {
+
+        char** uris;
+        if(drag_all){
+            uri_collection[uri_count] = NULL;
+            uris = uri_collection;
+        } else {
             char* a[] = {dd->uri, NULL};
-	    uris = a;
-	}
+            uris = a;
+        }
 
         gtk_selection_data_set_uris(data, uris);
         g_signal_stop_emission_by_name(widget, "drag-data-get");
@@ -127,11 +127,11 @@ GtkButton *add_button(char *label, struct draggable_thing *dragdata, int type) {
             G_CALLBACK(button_clicked), dragdata);
     g_signal_connect(GTK_WIDGET(button), "drag-end",
             G_CALLBACK(drag_end), dragdata);
- 
+
     gtk_container_add(GTK_CONTAINER(vbox), button);
 
     if(drag_all)
-    	uri_collection[uri_count++] = dragdata->uri;
+        uri_collection[uri_count++] = dragdata->uri;
 
     return (GtkButton *)button;
 }
@@ -291,9 +291,9 @@ int main (int argc, char **argv) {
         } else if (strcmp(argv[i], "-k") == 0
                 || strcmp(argv[i], "--keep") == 0) {
             keep = true;
-	} else if (strcmp(argv[i], "-a") == 0
-		|| strcmp(argv[i], "--all") == 0) {
-	    drag_all = true;
+        } else if (strcmp(argv[i], "-a") == 0
+                || strcmp(argv[i], "--all") == 0) {
+            drag_all = true;
         } else if (argv[i][0] == '-') {
             fprintf(stderr, "%s: error: unknown option `%s'.\n",
                     progname, argv[i]);
@@ -305,7 +305,7 @@ int main (int argc, char **argv) {
     GClosure *closure;
 
     gtk_init(&argc, &argv);
- 
+
     icon_theme = gtk_icon_theme_get_default();
 
     window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
@@ -314,10 +314,10 @@ int main (int argc, char **argv) {
     accelgroup = gtk_accel_group_new();
     gtk_accel_group_connect(accelgroup, GDK_KEY_Escape, 0, 0, closure);
     gtk_window_add_accel_group(GTK_WINDOW(window), accelgroup);
- 
+
     gtk_window_set_title(GTK_WINDOW(window), "Run");
     gtk_window_set_resizable(GTK_WINDOW(window), FALSE);
- 
+
     g_signal_connect(window, "destroy", G_CALLBACK(gtk_main_quit), NULL);
 
     vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 6);
@@ -352,10 +352,10 @@ int main (int argc, char **argv) {
         printf("Usage: %s [OPTIONS] FILENAME\n", progname);
         exit(0);
     }
- 
+
     gtk_widget_show_all(window);
- 
+
     gtk_main();
- 
+
     return 0;
 }

--- a/dragon.c
+++ b/dragon.c
@@ -84,7 +84,7 @@ void drag_data_get(GtkWidget    *widget,
     struct draggable_thing *dd = (struct draggable_thing *)user_data;
     if (info == TARGET_TYPE_URI) {
         if (verbose)
-            printf("Writing as URI: %s\n", dd->uri);
+            fprintf(stderr, "Writing as URI: %s\n", dd->uri);
 
         char** uris;
         if(drag_all){
@@ -99,7 +99,7 @@ void drag_data_get(GtkWidget    *widget,
         g_signal_stop_emission_by_name(widget, "drag-data-get");
     } else if (info == TARGET_TYPE_TEXT) {
         if (verbose)
-            printf("Writing as TEXT: %s\n", dd->text);
+            fprintf(stderr, "Writing as TEXT: %s\n", dd->text);
         gtk_selection_data_set_text(data, dd->text, -1);
     } else {
         fprintf(stderr, "Error: bad target type %i\n", info);

--- a/dragon.c
+++ b/dragon.c
@@ -107,8 +107,8 @@ void drag_data_get(GtkWidget    *widget,
 }
 
 GtkButton *add_button(char *label, struct draggable_thing *dragdata, int type) {
-    GtkWidget *button = gtk_button_new();
-    gtk_button_set_label(GTK_BUTTON(button), label);
+    GtkWidget *button = gtk_button_new_with_label(label);
+
     GtkTargetList *targetlist = gtk_drag_source_get_target_list(GTK_WIDGET(button));
     if (targetlist)
         gtk_target_list_ref(targetlist);
@@ -152,13 +152,18 @@ void add_file_button(char *filename) {
     GIcon *icon = g_file_info_get_icon(fileinfo);
     GtkIconInfo *icon_info = gtk_icon_theme_lookup_by_gicon(icon_theme,
             icon, 48, 0);
-    gtk_button_set_image(button,
-            gtk_image_new_from_pixbuf(
-                gtk_icon_info_load_icon(icon_info, NULL)
-                ));
-    gtk_button_set_alignment(button, 0, 0);
-    gtk_button_set_always_show_image(button, true);
 
+    if (icon_info) {
+        GtkWidget *image = gtk_image_new_from_pixbuf(
+                gtk_icon_info_load_icon(icon_info, NULL));
+        gtk_button_set_image(button, image);
+        gtk_button_set_always_show_image(button, true);
+    }
+
+    GList *child = g_list_first(
+            gtk_container_get_children(GTK_CONTAINER(button)));
+    if (child)
+        gtk_widget_set_halign(GTK_WIDGET(child->data), GTK_ALIGN_START);
 }
 
 void add_uri_button(char *uri) {

--- a/dragon.c
+++ b/dragon.c
@@ -136,6 +136,11 @@ GtkButton *add_button(char *label, struct draggable_thing *dragdata, int type) {
     return (GtkButton *)button;
 }
 
+GtkIconInfo* icon_info_from_content_type(char *content_type) {
+    GIcon *icon = g_content_type_get_icon(content_type);
+    return gtk_icon_theme_lookup_by_gicon(icon_theme, icon, 48, 0);
+}
+
 void add_file_button(char *filename) {
     GFile *file = g_file_new_for_path(filename);
     if(!g_file_query_exists(file, NULL)) {
@@ -147,11 +152,19 @@ void add_file_button(char *filename) {
     struct draggable_thing *dragdata = malloc(sizeof(struct draggable_thing));
     dragdata->text = filename;
     dragdata->uri = uri;
+
     GtkButton *button = add_button(filename, dragdata, TARGET_TYPE_URI);
     GFileInfo *fileinfo = g_file_query_info(file, "*", 0, NULL, NULL);
     GIcon *icon = g_file_info_get_icon(fileinfo);
     GtkIconInfo *icon_info = gtk_icon_theme_lookup_by_gicon(icon_theme,
             icon, 48, 0);
+    // Try a few fallback mimetypes if no icon can be found
+    if (!icon_info)
+        icon_info = icon_info_from_content_type("application/octet-stream");
+    if (!icon_info)
+        icon_info = icon_info_from_content_type("text/x-generic");
+    if (!icon_info)
+        icon_info = icon_info_from_content_type("text/plain");
 
     if (icon_info) {
         GtkWidget *image = gtk_image_new_from_pixbuf(


### PR DESCRIPTION
This is the first gtk "project" I worked on, so it took some getting used to, but I'm pretty confident in these changes. 

In summary, overall I

- added icon fallbacks if none can be found (and added a check to prevent triggering a ` icon_info != NULL` assertion),
- removed the deprecated `gtk_button_set_alignment` which took *way* longer than it should have,
- ~~#10 by printing the filepath instead of the URI (old behavior is behind an option now).~~ moved

For details, please refer to the individual commits. I considered splitting them into multiple PRs, but due to having to fix mixed whitespace indentation first I didn't want to run into merge conflicts.

Note that the latter change is breaking and I didn't increase the version.