### PR TITLE
Option to hide filename when serving as source

### DIFF
--- a/dragon.c
+++ b/dragon.c
@@ -221,7 +221,8 @@ void add_file_button(GFile *file) {
         gtk_button_set_always_show_image(button, true);
     }
 
-    left_align_button(button);
+    if (!icons_only)
+        left_align_button(button);
 }
 
 void add_filename_button(char *filename) {

--- a/dragon.c
+++ b/dragon.c
@@ -37,6 +37,7 @@ int mode = 0;
 bool and_exit;
 bool keep;
 bool print_path = false;
+bool print_names = true;
 
 #define MODE_HELP 1
 #define MODE_TARGET 2
@@ -133,7 +134,13 @@ void drag_end(GtkWidget *widget, GdkDragContext *context, gpointer user_data) {
 }
 
 GtkButton *add_button(char *label, struct draggable_thing *dragdata, int type) {
-    GtkWidget *button = gtk_button_new_with_label(label);
+    GtkWidget *button;
+    if (print_names) {
+        button = gtk_button_new_with_label(label);
+    }
+    else {
+        button = gtk_button_new();
+    }
 
     GtkTargetList *targetlist = gtk_drag_source_get_target_list(GTK_WIDGET(button));
     if (targetlist)
@@ -382,6 +389,9 @@ int main (int argc, char **argv) {
         } else if (strcmp(argv[i], "-a") == 0
                 || strcmp(argv[i], "--all") == 0) {
             drag_all = true;
+        } else if (strcmp(argv[i], "-i") == 0
+                || strcmp(argv[i], "--icon-only") == 0) {
+            print_names = false;
         } else if (argv[i][0] == '-') {
             fprintf(stderr, "%s: error: unknown option `%s'.\n",
                     progname, argv[i]);

--- a/dragon.c
+++ b/dragon.c
@@ -37,7 +37,7 @@ int mode = 0;
 bool and_exit;
 bool keep;
 bool print_path = false;
-bool print_names = true;
+bool icons_only = true;
 
 #define MODE_HELP 1
 #define MODE_TARGET 2
@@ -135,11 +135,12 @@ void drag_end(GtkWidget *widget, GdkDragContext *context, gpointer user_data) {
 
 GtkButton *add_button(char *label, struct draggable_thing *dragdata, int type) {
     GtkWidget *button;
-    if (print_names) {
-        button = gtk_button_new_with_label(label);
+
+    if (icons_only) {
+        button = gtk_button_new();
     }
     else {
-        button = gtk_button_new();
+        button = gtk_button_new_with_label(label);
     }
 
     GtkTargetList *targetlist = gtk_drag_source_get_target_list(GTK_WIDGET(button));
@@ -391,7 +392,7 @@ int main (int argc, char **argv) {
             drag_all = true;
         } else if (strcmp(argv[i], "-i") == 0
                 || strcmp(argv[i], "--icon-only") == 0) {
-            print_names = false;
+            icons_only = false;
         } else if (argv[i][0] == '-') {
             fprintf(stderr, "%s: error: unknown option `%s'.\n",
                     progname, argv[i]);


### PR DESCRIPTION
- Added -i (or --icon-only) option to display only icons when serving as source
- When displaying on icon only mode, the icons will be centered

The changes are pretty simple, since it only needs to check if the -i option is present and if so call gtk_button_new() instead of gtk_button_new_with_label() to return a button without the label and only call left_align_button() if -i is not present.