### PR TITLE
added thumbnails for image types gtk supports.

### DIFF
--- a/dragon.c
+++ b/dragon.c
@@ -201,24 +201,32 @@ void add_file_button(GFile *file) {
     dragdata->uri = uri;
 
     GtkButton *button = add_button(filename, dragdata, TARGET_TYPE_URI);
-    GFileInfo *fileinfo = g_file_query_info(file, "*", 0, NULL, NULL);
-    GIcon *icon = g_file_info_get_icon(fileinfo);
-    GtkIconInfo *icon_info = gtk_icon_theme_lookup_by_gicon(icon_theme,
-            icon, 48, 0);
-
-    // Try a few fallback mimetypes if no icon can be found
-    if (!icon_info)
-        icon_info = icon_info_from_content_type("application/octet-stream");
-    if (!icon_info)
-        icon_info = icon_info_from_content_type("text/x-generic");
-    if (!icon_info)
-        icon_info = icon_info_from_content_type("text/plain");
-
-    if (icon_info) {
-        GtkWidget *image = gtk_image_new_from_pixbuf(
-                gtk_icon_info_load_icon(icon_info, NULL));
+    GdkPixbuf *pb = gdk_pixbuf_new_from_file_at_size(filename, 96, 96, NULL);
+    if (pb) {
+        GtkWidget *image = gtk_image_new_from_pixbuf(pb);
+        gtk_button_set_always_show_image(button, true);
         gtk_button_set_image(button, image);
         gtk_button_set_always_show_image(button, true);
+    } else {
+        GFileInfo *fileinfo = g_file_query_info(file, "*", 0, NULL, NULL);
+        GIcon *icon = g_file_info_get_icon(fileinfo);
+        GtkIconInfo *icon_info = gtk_icon_theme_lookup_by_gicon(icon_theme,
+                icon, 48, 0);
+    
+        // Try a few fallback mimetypes if no icon can be found
+        if (!icon_info)
+            icon_info = icon_info_from_content_type("application/octet-stream");
+        if (!icon_info)
+            icon_info = icon_info_from_content_type("text/x-generic");
+        if (!icon_info)
+            icon_info = icon_info_from_content_type("text/plain");
+    
+        if (icon_info) {
+            GtkWidget *image = gtk_image_new_from_pixbuf(
+                    gtk_icon_info_load_icon(icon_info, NULL));
+            gtk_button_set_image(button, image);
+            gtk_button_set_always_show_image(button, true);
+        }
     }
 
     if (!icons_only)


### PR DESCRIPTION
other file types fall back on old mimetype icons.

here's an example of the file types gtk supports and another file falling back on a generic icon.
![2021-02-07-08-32-28](https://user-images.githubusercontent.com/10301602/107148063-2e806080-691f-11eb-8103-15231bd4e0b7.png)

this covers as much of [issue 25](https://github.com/mwh/dragon/issues/25) as i think is possible without using external programs.
