### PR TITLE
Added a flag to set multiple different targets

### DIFF
--- a/dragon.c
+++ b/dragon.c
@@ -525,7 +525,7 @@ int main (int argc, char **argv) {
         } else if (strcmp(argv[i], "--targets") == 0) {
             mode = MODE_TARGET;
             targets = &argv[i+1];
-            while (argv[i+1] != NULL && strncmp(argv[i+1], "-", 1) != 0) {
+            while (argv[i+1] != NULL && argv[i+1][0] != '-') {
                 num_targets++;
                 i++;
             }


### PR DESCRIPTION
Hi,
I don't know whether this is useful to anyone else, but I added a flag to set multiple different drag-targets with different names.
When using this flag, the filename is prefixed with the name of the button when writing to stdout.

As an example for why this might be useful. I want to use it to quickly tag files by dragging them onto different buttons:
```bash
./dragon --targets a b c -p |
while IFS= read -r line; do
  tag="${line%%:*}"
  file="${line#*:}"
  echo "setting tag $tag for file '$file'."
  tmsu tag "$file" "$tag"
done
```
Here I make three different buttons (a, b and c) and can assign a tag (with [TMSU](https://github.com/oniony/TMSU)) to a file by dragging that file on the corresponding button.