### PR TITLE
Minor UI changes: Filename only, tooltip, and scrolling

### DIFF
--- a/dragon.1
+++ b/dragon.1
@@ -10,6 +10,7 @@ dragon \- lightweight DnD source/target
 .OP -a
 .OP -A
 .OP -i
+.OP -f
 .OP -T
 .OP -I
 .OP -s
@@ -49,6 +50,9 @@ drag all files at once, only displaying the number of files.
 .TP
 .B -i --icon-only
 only show icons in drag-and-drop windows.
+.TP
+.B -f --name-only
+only show the file name, not path.
 .TP
 .B -T --on-top
 make window always-on-top.

--- a/dragon.c
+++ b/dragon.c
@@ -27,8 +27,15 @@
 #define VERSION "1.2.0"
 
 
+// Top-level window.
 GtkWidget *window;
+
+// Container providing the scrolling.
+GtkWidget *panel;
+
+// Child of panel, where all the children are added.
 GtkWidget *vbox;
+
 GtkIconTheme *icon_theme;
 
 char *progname;
@@ -551,6 +558,9 @@ int main (int argc, char **argv) {
 
     window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
 
+    // Scrolling Window
+    panel = gtk_scrolled_window_new(NULL, NULL);
+
     closure = g_cclosure_new(G_CALLBACK(do_quit), NULL, NULL);
     accelgroup = gtk_accel_group_new();
     gtk_accel_group_connect(accelgroup, GDK_KEY_Escape, 0, 0, closure);
@@ -566,7 +576,9 @@ int main (int argc, char **argv) {
 
     vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 6);
 
-    gtk_container_add(GTK_CONTAINER(window), vbox);
+    gtk_container_add(GTK_CONTAINER(panel), vbox);
+
+    gtk_container_add(GTK_CONTAINER(window), panel);
 
     gtk_window_set_title(GTK_WINDOW(window), "dragon");
 

--- a/dragon.c
+++ b/dragon.c
@@ -214,12 +214,16 @@ GtkIconInfo* icon_info_from_content_type(char *content_type) {
 }
 
 void add_file_button(GFile *file) {
-    char *filename;
-
     // When the filename only option is set, only the file's basename including
-    // extenion is displayed, not the entire path.
+    // extension is displayed, not the entire path. The button's label is
+    // obtained from the file argument and depending on `filename_only`, may
+    // be either the basename or the full path. However, the full path is
+    // necessary to get the pixel buffer for image as well as for the button's
+    // tooltip.
+    char *filename;
+    char *path = g_file_get_path(file);
+
     if (filename_only) {
-      char *path = g_file_get_path(file);
       filename = g_path_get_basename(path);
     } else {
       filename = g_file_get_path(file);
@@ -240,7 +244,7 @@ void add_file_button(GFile *file) {
     dragdata->uri = uri;
 
     GtkButton *button = add_button(filename, dragdata, TARGET_TYPE_URI);
-    GdkPixbuf *pb = gdk_pixbuf_new_from_file_at_size(filename, thumb_size, thumb_size, NULL);
+    GdkPixbuf *pb = gdk_pixbuf_new_from_file_at_size(path, thumb_size, thumb_size, NULL);
     if (pb) {
         GtkWidget *image = gtk_image_new_from_pixbuf(pb);
         gtk_button_set_always_show_image(button, true);

--- a/dragon.c
+++ b/dragon.c
@@ -159,7 +159,7 @@ void add_uri(char *uri) {
     }
 }
 
-GtkButton *add_button(char *label, struct draggable_thing *dragdata, int type) {
+GtkButton *add_button(char *label, struct draggable_thing *dragdata, int type, char *tooltip) {
     GtkWidget *button;
 
     if (icons_only) {
@@ -168,8 +168,9 @@ GtkButton *add_button(char *label, struct draggable_thing *dragdata, int type) {
         button = gtk_button_new_with_label(label);
     }
 
-    // Show a tooltip with the filename. Should perhaps show the full path.
-    gtk_widget_set_tooltip_text(button, label);
+    // Show a tooltip based on `tooltip` or the button's intended label.
+    // Ideally, the value is the file's full path.
+    gtk_widget_set_tooltip_text(button, tooltip != NULL ? tooltip : label);
 
     GtkTargetList *targetlist = gtk_drag_source_get_target_list(GTK_WIDGET(button));
     if (targetlist)
@@ -220,14 +221,8 @@ void add_file_button(GFile *file) {
     // be either the basename or the full path. However, the full path is
     // necessary to get the pixel buffer for image as well as for the button's
     // tooltip.
-    char *filename;
     char *path = g_file_get_path(file);
-
-    if (filename_only) {
-      filename = g_path_get_basename(path);
-    } else {
-      filename = g_file_get_path(file);
-    }
+    char *filename = filename_only ? g_path_get_basename(path) : g_file_get_path(file);
 
     if(!g_file_query_exists(file, NULL)) {
         fprintf(stderr, "The file `%s' does not exist.\n",
@@ -243,7 +238,7 @@ void add_file_button(GFile *file) {
     dragdata->text = filename;
     dragdata->uri = uri;
 
-    GtkButton *button = add_button(filename, dragdata, TARGET_TYPE_URI);
+    GtkButton *button = add_button(filename, dragdata, TARGET_TYPE_URI, path);
     GdkPixbuf *pb = gdk_pixbuf_new_from_file_at_size(path, thumb_size, thumb_size, NULL);
     if (pb) {
         GtkWidget *image = gtk_image_new_from_pixbuf(pb);
@@ -289,7 +284,7 @@ void add_uri_button(char *uri) {
     struct draggable_thing *dragdata = malloc(sizeof(struct draggable_thing));
     dragdata->text = uri;
     dragdata->uri = uri;
-    GtkButton *button = add_button(uri, dragdata, TARGET_TYPE_URI);
+    GtkButton *button = add_button(uri, dragdata, TARGET_TYPE_URI, NULL);
     left_align_button(button);
 }
 

--- a/dragon.c
+++ b/dragon.c
@@ -484,7 +484,7 @@ int main (int argc, char **argv) {
                     " the number of files\n");
             printf("  --icon-only,   -i  only show icons in drag-and-drop"
                     " windows\n");
-            printf("  --name-only,  -f  only show the file's basename and"
+            printf("  --name-only,   -f  only show the file's basename and"
                    " not the full path\n");
             printf("  --on-top,      -T  make window always-on-top\n");
             printf("  --stdin,       -I  read input from stdin\n");

--- a/dragon.c
+++ b/dragon.c
@@ -39,6 +39,7 @@ bool and_exit;
 bool keep;
 bool print_path = false;
 bool icons_only = false;
+bool filename_only = false;
 bool always_on_top = false;
 
 static char *stdin_files;
@@ -202,7 +203,17 @@ GtkIconInfo* icon_info_from_content_type(char *content_type) {
 }
 
 void add_file_button(GFile *file) {
-    char *filename = g_file_get_path(file);
+    char *filename;
+
+    // When the filename only option is set, only the file's basename including
+    // extenion is displayed, not the entire path.
+    if (filename_only) {
+      char *path = g_file_get_path(file);
+      filename = g_path_get_basename(path);
+    } else {
+      filename = g_file_get_path(file);
+    }
+
     if(!g_file_query_exists(file, NULL)) {
         fprintf(stderr, "The file `%s' does not exist.\n",
                 filename);
@@ -463,6 +474,8 @@ int main (int argc, char **argv) {
                     " the number of files\n");
             printf("  --icon-only,   -i  only show icons in drag-and-drop"
                     " windows\n");
+            printf("  --name-only,  -f  only show the file's basename and"
+                   " not the full path\n");
             printf("  --on-top,      -T  make window always-on-top\n");
             printf("  --stdin,       -I  read input from stdin\n");
             printf("  --thumb-size,  -s  set thumbnail size (default 96)\n");
@@ -502,6 +515,9 @@ int main (int argc, char **argv) {
         } else if (strcmp(argv[i], "-i") == 0
                 || strcmp(argv[i], "--icon-only") == 0) {
             icons_only = true;
+        } else if (strcmp(argv[i], "-f") == 0
+                || strcmp(argv[i], "--name-only") == 0) {
+            filename_only = true;
         } else if (strcmp(argv[i], "-T") == 0
                 || strcmp(argv[i], "--on-top") == 0) {
             always_on_top = true;

--- a/dragon.c
+++ b/dragon.c
@@ -160,6 +160,9 @@ GtkButton *add_button(char *label, struct draggable_thing *dragdata, int type) {
         button = gtk_button_new_with_label(label);
     }
 
+    // Show a tooltip with the filename. Should perhaps show the full path.
+    gtk_widget_set_tooltip_text(button, label);
+
     GtkTargetList *targetlist = gtk_drag_source_get_target_list(GTK_WIDGET(button));
     if (targetlist)
         gtk_target_list_ref(targetlist);

--- a/dragon.c
+++ b/dragon.c
@@ -25,7 +25,8 @@
 #include <string.h>
 
 #define VERSION "1.2.0"
-
+#define MIN_WIDTH 640
+#define MIN_HEIGHT 480
 
 // Top-level window.
 GtkWidget *window;
@@ -571,6 +572,23 @@ int main (int argc, char **argv) {
     gtk_window_set_title(GTK_WINDOW(window), "Run");
     gtk_window_set_resizable(GTK_WINDOW(window), FALSE);
     gtk_window_set_keep_above(GTK_WINDOW(window), always_on_top);
+
+    // Set the default window size so the scroll window has place to work,
+    // as it doesn't set the size itself.
+    GdkDisplay *display = gdk_display_get_default();
+    GdkMonitor *monitor = gdk_display_get_monitor(display, 0);
+    GdkRectangle *workarea = malloc(sizeof(GdkRectangle));
+
+    gdk_monitor_get_workarea(monitor, workarea);
+
+    GdkGeometry *geometry = malloc(sizeof(GdkGeometry));
+    geometry->min_width = MIN_WIDTH;
+    geometry->min_height = MIN_HEIGHT;
+    geometry->max_width = workarea->width;
+    geometry->max_height = workarea->height;
+
+    gtk_window_set_geometry_hints(GTK_WINDOW(window), NULL, geometry, GDK_HINT_MIN_SIZE | GDK_HINT_MAX_SIZE);
+    gtk_window_set_default_size(GTK_WINDOW(window), workarea->width, workarea->height);
 
     g_signal_connect(window, "destroy", G_CALLBACK(gtk_main_quit), NULL);
 


### PR DESCRIPTION
This pull request contains a few minor user-facing changes:

+ CLI switch to only show the filename, not the full path (enabled with -f/--name-only).
+ Show a tooltip containing the full path when hovering over a file.
+ Use `gtk_scrolled_window_new` to allow scrolling when there are many items.

They've been kept separate as to cherry pick the desired features.